### PR TITLE
Correct castling rules in chess-game.md

### DIFF
--- a/chess/1-chess-game/chess-game.md
+++ b/chess/1-chess-game/chess-game.md
@@ -85,12 +85,11 @@ You do not have to implement these moves, but if you go the extra mile and succe
 
 **`Castling`**
 
-This is a special move where the King and a Rook move simultaneously. The castling move can only be taken when 4 conditions are met:
+This is a special move where the King and a Rook move simultaneously. The castling move can only be taken when 3 conditions are met:
 
 1. Neither the King nor Rook have moved since the game started
 2. There are no pieces between the King and the Rook
-3. The King is not in Check
-4. Both your Rook and King will be safe after making the move (cannot be captured by any enemy pieces).
+3. The King is not in Check, does not cross a square on which it would be in Check, or land on a square on which it would be in Check
 
 To Castle, the King moves 2 spaces towards the Rook, and the Rook "jumps" the king moving to the position next to and on the other side of the King. This is represented in a ChessMove as the king moving 2 spaces to the side.
 


### PR DESCRIPTION
The castling rules detailed are incorrect. Castling is still valid if the Rook can be captured - this rule only applies to the King. In addition, the King cannot castle through a square on which it would be in Check.